### PR TITLE
refactor: extract getAuthHeaders to a reusable helper

### DIFF
--- a/src/services/ArticlesServices.jsx
+++ b/src/services/ArticlesServices.jsx
@@ -1,19 +1,12 @@
-import { useAuthStore } from "../store/authStore"
+import { getAuthHeaders } from "./apiHelpers";
 
 const URL_API = "http://localhost:8000/posts"
-const EXPANDED_URL =  `${URL_API}?_expand=user&_expand=categories`
-
-// zustand
-function getAuthHeaders() {
-  const token = useAuthStore.getState().token;
-  return token
-    ? { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
-    : { "Content-Type": "application/json" };
-}
+const EXPANDED_URL = `${URL_API}?_expand=user&_expand=categories`
 
 //GET METHOD
 export async function getAllArticles() {
-    const response = await fetch(EXPANDED_URL, {headers: getAuthHeaders(),        
+    const response = await fetch(EXPANDED_URL, {
+        headers: getAuthHeaders(),
     })
     if (!response.ok) {
         throw new Error('Error al obtener los artículos')
@@ -25,9 +18,10 @@ export async function getAllArticles() {
 //GET/:ID
 export async function getOneArticle(id) {
     // const response = await fetch (`${URL_API}/${id}`)
-    const response = await fetch (`${URL_API}/${id}?_expand=user&_expand=categories`, {headers: getAuthHeaders(), 
-        
-});
+    const response = await fetch(`${URL_API}/${id}?_expand=user&_expand=categories`, {
+        headers: getAuthHeaders(),
+
+    });
     if (!response.ok) throw new Error('Error al obtener el artículo')
     return response.json()
 }

--- a/src/services/UsersServices.jsx
+++ b/src/services/UsersServices.jsx
@@ -1,27 +1,33 @@
 const URL_API_USERS = "http://localhost:8000/users"
 const URL_API_POSTS = "http://localhost:8000/posts"
+import { getAuthHeaders } from "./apiHelpers";
 
 //GET method
 export async function getAllUsers() {
-    const response = await fetch(URL_API_USERS)
+    const response = await fetch(URL_API_USERS, {
+        headers: getAuthHeaders()
+    });
     if (!response.ok) {
         throw new Error('Error al obtener los usuarios')
     }
-
     return response.json()
 }
 
 //GET/:id method
 export async function getOneUser(id) {
-    const response = await fetch(`${URL_API_USERS}/${id}`)
+    const response = await fetch(`${URL_API_USERS}/${id}`, {
+        headers: getAuthHeaders()
+    });
     if (!response.ok) throw new Error('Error al obtener el usuario')
     return response.json()
 }
 
 export async function getUserPosts(authorId) {
-    const response = await fetch(`${URL_API_POSTS}?author_id=${authorId}`)
+    const response = await fetch(`${URL_API_POSTS}?author_id=${authorId}`, {
+        headers: getAuthHeaders()
+    });
     if (!response.ok) throw new Error("Error al obtener los posts del usuario");
-    return response.json()
+    return response.json();
 }
 // PUT o PATCH /users/:id → { data: User }
 export const updateUser = async (id, payload, { method = "put" } = {}) => {
@@ -32,6 +38,8 @@ export const updateUser = async (id, payload, { method = "put" } = {}) => {
 
 // DELETE /users/:id → { message }
 export const deleteUser = async (id) => {
-    const res = await api.delete(`/users/${id}`);
+    const res = await api.delete(`/users/${id}`, {
+        headers: getAuthHeaders()
+    });
     return res.data; // { message }
 };

--- a/src/services/apiHelpers.js
+++ b/src/services/apiHelpers.js
@@ -1,0 +1,9 @@
+import { useAuthStore } from "../store/authStore";
+
+// zustand
+export function getAuthHeaders() {
+    const token = useAuthStore.getState().token;
+    return token
+        ? { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" };
+}


### PR DESCRIPTION
Se ha creado un archivo apiHelpers.ts en la carpeta services para centralizar la función getAuthHeaders. 